### PR TITLE
swtched from curl request to expect command to SSH into power strip

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ mPowerAccessory.prototype.setState = function(state, callback) {
 			for (var i = 0; i < response.length; i++){
 				response[i] = response[i].trim();
 			}
-
+	    this.log("set " + this.name + " outlet to " + state + " and checked OnOff state for " + this.name + " outlet is " + response[0] + ".");
             if(response[0] == state) {
               callback(null);
             } else {
@@ -116,6 +116,7 @@ mPowerAccessory.prototype.getState = function(callback) {
 			for (var i = 0; i < state.length; i++){
 				state[i] = state[i].trim();
 			}
+	    this.log("OnOff state for " + this.name + " outlet is " + state[0] + ".");
             if(state[0] == 1) {
               callback(null, true);
             } else if(state[0] == 0) {
@@ -147,12 +148,13 @@ mPowerAccessory.prototype.getOutletInUse = function(callback) {
 			for (var i = 0; i < inUseState.length; i++){
 				inUseState[i] = inUseState[i].trim();
 			}
+	    this.log("inUseState value for " + this.name + " outlet is " + inUseState[0] + ".");
             if(inUseState[0] != "0.0") {
               callback(null, true);
             } else if(inUseState[0] == "0.0") {
               callback(null, false);
             }
-			else {
+	    else {
               callback(error);
             }
           } else {

--- a/index.js
+++ b/index.js
@@ -41,7 +41,6 @@ mPowerPlatform.prototype = {
 };
 
 function mPowerAccessory(log, airos_sessionid, outlet) {
-  // global vars
   this.log = log;
   this.airos_sessionid = airos_sessionid;
   
@@ -67,7 +66,6 @@ function mPowerAccessory(log, airos_sessionid, outlet) {
   this.outletService
     .getCharacteristic(Characteristic.OutletInUse)
     .on('get', this.getOutletInUse.bind(this));
-  //  .setValue(this.state === 'on');
 
   this.services.push(this.outletService);
 }
@@ -75,6 +73,7 @@ function mPowerAccessory(log, airos_sessionid, outlet) {
 mPowerAccessory.prototype.setState = function(state, callback) {
   var exec = require('child_process').exec;
   
+  //use expect to SSH to powerstrip to send on off commands directly on powerstrip
   var cmdUpdate = 'expect -c "set timeout 5; spawn ssh -oStrictHostKeyChecking=no ' + this.url + ' -l ' + this.username + '; expect \\"password: \\"; send \\"' + this.password + '\\"; send \\"\\r\\"; expect \\"#\\"; send \\"echo ' + state + ' > /proc/power/relay' + this.id + '\\r\\"; expect \\"#\\"; send \\"cd /proc/power;grep \'\' relay' + this.id + '* \\r\\"; expect \\"#\\"; send \\"exit\\r\\";"'
   
   var stateName = (state == 1) ? 'on' : 'off';
@@ -105,6 +104,7 @@ mPowerAccessory.prototype.setState = function(state, callback) {
 mPowerAccessory.prototype.getState = function(callback) {
   var exec = require('child_process').exec;
 
+  //use expect to SSH to powerstrip to get state directly from powerstrip
   var cmdStatus = 'expect -c "set timeout 5; spawn ssh -oStrictHostKeyChecking=no ' + this.url + ' -l ' + this.username + '; expect \\"password: \\"; send \\"' + this.password + '\\r\\"; expect \\"#\\"; send \\"cd /proc/power;grep \'\' relay' + this.id + '* \\r\\"; expect \\"#\\"; send \\"exit\\r\\";"'
 
 
@@ -136,6 +136,7 @@ mPowerAccessory.prototype.getState = function(callback) {
 mPowerAccessory.prototype.getOutletInUse = function(callback) {
   var exec = require('child_process').exec;
 
+  //use expect to SSH to powerstrip to get in use state directly from power strip
   var cmdOutletInUseStatus = 'expect -c "set timeout 5; spawn ssh -oStrictHostKeyChecking=no ' + this.url + ' -l ' + this.username + '; expect \\"password: \\"; send \\"' + this.password + '\\r\\"; expect \\"#\\"; send \\"cd /proc/power;grep \'\' active_pwr' + this.id + '* \\r\\"; expect \\"#\\"; send \\"exit\\r\\";"'
   
       exec(cmdOutletInUseStatus, function(error, stdout, stderr) {

--- a/index.js
+++ b/index.js
@@ -164,39 +164,6 @@ mPowerAccessory.prototype.getOutletInUse = function(callback) {
       });
 }
 
-mPowerAccessory.prototype.getOutletInUse = function(callback) {
-  var exec = require('child_process').exec;
-
-  var cmdAuth = 'curl -X POST -d "username=' + this.username + '&password=' + this.password + '" -b "AIROS_SESSIONID=' + this.airos_sessionid + '" ' + this.url + '/login.cgi';
-  var cmdStatus = 'curl -b "AIROS_SESSIONID=' + this.airos_sessionid + '" ' + this.url + '/sensors/' + this.id + '/power';
-
-  exec(cmdAuth, function(error, stdout, stderr) {
-    if (!error) {
-      exec(cmdStatus, function(error, stdout, stderr) {
-        if (!error) {
-          if (stdout != "") {
-            var state = JSON.parse(stdout);
-            if(state.sensors[0].power > 0) {
-              callback(null, true);
-            } else if(state.sensors[0].power == 0) {
-              callback(null, false);
-            }
-			else {
-              callback(error);
-            }
-          } else {
-            console.log("Failed to communicate with mPower accessory");
-          }
-        } else {
-          console.log("Failed with error: " + error);
-        }
-      });
-    } else {
-      console.log("Failed with error: " + error);
-    }
-  });
-}
-
 mPowerAccessory.prototype.getDefaultValue = function(callback) {
   callback(null, this.value);
 }

--- a/index.js
+++ b/index.js
@@ -43,11 +43,8 @@ mPowerPlatform.prototype = {
 function mPowerAccessory(log, airos_sessionid, outlet) {
   this.log = log;
   this.airos_sessionid = airos_sessionid;
-<<<<<<< HEAD
   
   // configuration vars
-=======
->>>>>>> refs/remotes/wr/master
   this.name = outlet["name"];
   this.username = outlet["username"];
   this.password = outlet["password"];

--- a/index.js
+++ b/index.js
@@ -50,8 +50,7 @@ function mPowerAccessory(log, airos_sessionid, outlet) {
   this.password = outlet["password"];
   this.url = outlet["url"];
   this.id = outlet["id"];
- 
-
+  
   // register the service and provide the functions
   this.services = [];
   this.outletService = new Service.Outlet(this.name);
@@ -72,11 +71,12 @@ function mPowerAccessory(log, airos_sessionid, outlet) {
 
 mPowerAccessory.prototype.setState = function(state, callback) {
   var exec = require('child_process').exec;
-  
+  state = (state == true) ? 1 : 0;
+  var stateName = (state == 1) ? 'on' : 'off';
   //use expect to SSH to powerstrip to send on off commands directly on powerstrip
   var cmdUpdate = 'expect -c "set timeout 5; spawn ssh -oStrictHostKeyChecking=no ' + this.url + ' -l ' + this.username + '; expect \\"password: \\"; send \\"' + this.password + '\\"; send \\"\\r\\"; expect \\"#\\"; send \\"echo ' + state + ' > /proc/power/relay' + this.id + '\\r\\"; expect \\"#\\"; send \\"cd /proc/power;grep \'\' relay' + this.id + '* \\r\\"; expect \\"#\\"; send \\"exit\\r\\";"'
-  
-  var stateName = (state == 1) ? 'on' : 'off';
+  //this.log("state variable = " + state + ".");
+
 
   this.log("Turning " + this.name + " outlet " + stateName + ".");
 
@@ -88,7 +88,7 @@ mPowerAccessory.prototype.setState = function(state, callback) {
 			for (var i = 0; i < response.length; i++){
 				response[i] = response[i].trim();
 			}
-	    this.log("set " + this.name + " outlet to " + state + " and checked OnOff state for " + this.name + " outlet is " + response[0] + ".");
+	   //console.log("set " + this.name + " outlet to " + state + " and checked OnOff state for " + this.name + " outlet is " + response[0] + ".");
             if(response[0] == state) {
               callback(null);
             } else {
@@ -116,7 +116,7 @@ mPowerAccessory.prototype.getState = function(callback) {
 			for (var i = 0; i < state.length; i++){
 				state[i] = state[i].trim();
 			}
-	    this.log("OnOff state for " + this.name + " outlet is " + state[0] + ".");
+	    //console.log("OnOff state for " + this.name + " outlet is " + state[0] + ".");
             if(state[0] == 1) {
               callback(null, true);
             } else if(state[0] == 0) {
@@ -148,7 +148,7 @@ mPowerAccessory.prototype.getOutletInUse = function(callback) {
 			for (var i = 0; i < inUseState.length; i++){
 				inUseState[i] = inUseState[i].trim();
 			}
-	    this.log("inUseState value for " + this.name + " outlet is " + inUseState[0] + ".");
+	    //console.log("inUseState value for " + this.name + " outlet is " + inUseState[0] + ".");
             if(inUseState[0] != "0.0") {
               callback(null, true);
             } else if(inUseState[0] == "0.0") {

--- a/index.js
+++ b/index.js
@@ -84,7 +84,7 @@ mPowerAccessory.prototype.setState = function(state, callback) {
       exec(cmdUpdate, function(error, stdout, stderr) {
         if (!error) {
           if (stdout != "") {
-			var lines = stdout.toString().split('\n');
+	    var lines = stdout.toString().split('\n');
             var response = lines.splice(9,1);
 			for (var i = 0; i < response.length; i++){
 				response[i] = response[i].trim();
@@ -111,7 +111,7 @@ mPowerAccessory.prototype.getState = function(callback) {
       exec(cmdStatus, function(error, stdout, stderr) {
         if (!error) {
           if (stdout != "") {
-			var lines = stdout.toString().split('\n');
+	    var lines = stdout.toString().split('\n');
             var state = lines.splice(8,1);
 			for (var i = 0; i < state.length; i++){
 				state[i] = state[i].trim();


### PR DESCRIPTION
Referenced this page to learn about how to SSH to the power strip directly to run commands.
It shows what commands to run to directly turn on and off outlets once you ssh into the powerstrip.
https://community.ubnt.com/t5/mFi/Commands-via-SSH-on-mFi/td-p/418751
There are also commands to check for status of outlets.

My outlets seem more responsive now. I think it is because i'm running one command to access the powerstrip instead of two. Also no need to mess with cookies via ssh.

I used expect to ssh into the powerstrip and run the commands to set state and get state.
Example commands below. The commands are strung together on one line. You should be able to run this from where you have homebridge running to see the commands in action.
//set outlet to OFF state, change relay1 to relay2, relay3 etc....
expect -c "set timeout 5; spawn ssh -oStrictHostKeyChecking=no 192.168.1.128 -l ubnt; expect \"password: \"; send \"ubnt\"; send \"\r\"; expect \"#\"; send \"echo 0 > /proc/power/relay1\r\"; expect \"#\"; send \"exit\r\";"

//set outlet to ON state, change relay1 to relay2, relay3 etc....
expect -c "set timeout 5; spawn ssh -oStrictHostKeyChecking=no 192.168.1.128 -l ubnt; expect \"password: \"; send \"ubnt\"; send \"\r\"; expect \"#\"; send \"echo 1 > /proc/power/relay1\r\"; expect \"#\"; send \"cd /proc/power;grep '' relay3* \r\"; expect \"#\"; send \"exit\r\";"


// get outlet status values one at a time
///outlet on or off state
expect -c "set timeout 5; spawn ssh -oStrictHostKeyChecking=no 192.168.1.128 -l ubnt; expect \"password: \"; send \"ubnt\r\"; expect \"#\"; send \"cd /proc/power;grep '' relay1* \r\"; expect \"#\"; send \"exit\r\";"

//power details
expect -c "set timeout 5; spawn ssh -oStrictHostKeyChecking=no 192.168.1.128 -l ubnt; expect \"password: \"; send \"ubnt\r\"; expect \"#\"; send \"cd /proc/power;grep '' active_pwr1* \r\"; expect \"#\"; send \"exit\r\";"

expect -c "set timeout 5; spawn ssh -oStrictHostKeyChecking=no 192.168.1.128 -l ubnt; expect \"password: \"; send \"ubnt\r\"; expect \"#\"; send \"cd /proc/power;grep '' pf1* \r\"; expect \"#\"; send \"exit\r\";"

expect -c "set timeout 5; spawn ssh -oStrictHostKeyChecking=no 192.168.1.128 -l ubnt; expect \"password: \"; send \"ubnt\r\"; expect \"#\"; send \"cd /proc/power;grep '' v_rms1* \r\"; expect \"#\"; send \"exit\r\";"

expect -c "set timeout 5; spawn ssh -oStrictHostKeyChecking=no 192.168.1.128 -l ubnt; expect \"password: \"; send \"ubnt\r\"; expect \"#\"; send \"cd /proc/power;grep '' energy_sum1* \r\"; expect \"#\"; send \"exit\r\";"

//get list of all outlet status values
expect -c "set timeout 5; spawn ssh -oStrictHostKeyChecking=no 192.168.1.128 -l ubnt; expect \"password: \"; send \"ubnt\r\"; expect \"#\"; send \"cd /proc/power;grep '' relay* v_rms* active_pwr* pf* energy_sum* \r\"; expect \"#\"; send \"exit\r\";"